### PR TITLE
Fixed duplicate record entries in csv session history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.1] - 2026-04-06
+
+### Fixed
+- **Prevent duplicate CSV entries from currentrecord**: the THOR firmware occasionally sends two identical `currentrecord` DataTransfer messages within seconds after a session ends. A deduplication check on `transactionId` + `endtime` now prevents the same frozen record from being processed and written to CSV twice.
+Note: You still need to manually remove the duplicate records from the CSV (/homeassistant/growatt_thor_sessions.csv). This is fairly easy to do with the file editor (found in the Home Assistant app store).
+
+---
+
 ## [1.5.0]  - 2026-03-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+[!["Buy Me A Coffee"](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/bobbesnl)
+
 [![HACS](https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
-![Version](https://img.shields.io/badge/version-1.2.0-blue)
+![Version](https://img.shields.io/badge/version-1.5.1-blue)
 
 
 ⚠️ **Please read this document first before installing this integration!**

--- a/custom_components/growatt_thor/coordinator.py
+++ b/custom_components/growatt_thor/coordinator.py
@@ -70,6 +70,7 @@ class GrowattCoordinator(DataUpdateCoordinator):
         self.last_session_transaction_id = None   # str
         self.last_session_charge_mode = None      # str
         self.last_session_work_mode = None        # str
+        self._last_frozen_record_key = None
 
         # ── Cumulatief totaal (persistent) ─
         self.total_energy_charged = 0.0           # kWh
@@ -464,10 +465,20 @@ class GrowattCoordinator(DataUpdateCoordinator):
     def process_frozen_record(self, data: dict):
         """Process Growatt frozen record and update session sensors + persistent total."""
         try:
+            # Deduplication: skip if same transaction_id and end_time as last processed
+            transaction_id = data.get("transactionId", "")
+            end_str = data.get("endtime", "")
+            dedup_key = f"{transaction_id}_{end_str}"
+
+            if self._last_frozen_record_key == dedup_key:
+                _LOGGER.debug("⏭️ Duplicate frozen record skipped (transaction=%s)", transaction_id)
+                return
+
+            self._last_frozen_record_key = dedup_key
+
             energy_kwh = float(data.get("costenergy", 0)) / 1000
             cost = float(data.get("costmoney", 0)) / 100
             start_str = data.get("starttime", "")
-            end_str = data.get("endtime", "")
 
             duration_minutes = None
             try:
@@ -484,7 +495,7 @@ class GrowattCoordinator(DataUpdateCoordinator):
             self.last_session_plug_time = data.get("plugtime", "")
             self.last_session_unplug_time = data.get("unplugtime", "")
             self.last_session_duration_minutes = duration_minutes
-            self.last_session_transaction_id = data.get("transactionId", "")
+            self.last_session_transaction_id = transaction_id
             self.last_session_charge_mode = data.get("chargemode", "")
             self.last_session_work_mode = data.get("workmode", "")
 

--- a/custom_components/growatt_thor/manifest.json
+++ b/custom_components/growatt_thor/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/bobbesnl/growatt_thor/issues",
   "loggers": ["custom_components.growatt_thor"],
   "requirements": ["ocpp>=2.0.0"],
-  "version": "1.5.0"
+  "version": "1.5.1"
 }


### PR DESCRIPTION
### Fixed
- **Prevent duplicate CSV entries from currentrecord**: the THOR firmware occasionally sends two identical `currentrecord` DataTransfer messages within seconds after a session ends. A deduplication check on `transactionId` + `endtime` now prevents the same frozen record from being processed and written to CSV twice.